### PR TITLE
Add OpenShift Connector to the Workspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.access.redhat.com/ubi8/openjdk-11
+COPY target/*.jar /opt/spring-petclinic.jar
+CMD java -jar /opt/spring-petclinic.jar
+EXPOSE 8080

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -12,6 +12,8 @@ components:
     type: chePlugin
   - id: redhat/dependency-analytics/latest
     type: chePlugin
+  - id: redhat/vscode-openshift-connector/latest
+    type: chePlugin
   - mountSources: true
     endpoints:
       - name: 8080-tcp


### PR DESCRIPTION
Adding OpenShift Connector will allow developers pushing the app directly from CRW as another strategy for deploying changes