### PR TITLE
Update to readme to avoid issues with Edit Source Code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ In a production system, you will most likely be using a permanent MySQL instance
 
 Click the `+Add` button and choose `From Git` type:
 
-Fill the git repo with the following value `https://github.com/redhat-developer-demos/spring-petclinic` and select the project as Java project:
+Fill the git repo with the following value `https://github.com/redhat-developer-demos/spring-petclinic` and select the project as Java project. Expand `Show advanced Git options` and for `Git reference`specify 'main' (or an alternative branch if appropriate). This will ensure the `Edit Source Code` option from the OpenShift Topology view works correctly; 'master' is assumed if this value is ommitted.
 
 ![Pet Clinic Deploy](images/7-petclinic-deploy.png)
 


### PR DESCRIPTION
When you add from git without changing defaults, the branch is currently assumed to be `master` and this is set in the `app.openshift.io/vcs-ref` annotation. This value is used as part of creating the factory URL for CodeReady Workspaces / Eclipse Che, and if the repo doesnt have a `master` branch it will be unable to clone and fail with 'Remote branch master not found in upstream origin'